### PR TITLE
Fix: Align destination width to 32 for hardware decoder compatibility

### DIFF
--- a/src/video/hffplayer.cpp
+++ b/src/video/hffplayer.cpp
@@ -233,7 +233,8 @@ try_software_decode:
         return ret;
     }
 
-    dw = sw >> 2 << 2; // align = 4
+    // dw = sw >> 2 << 2; // align = 4
+    dw = FFALIGN(sw, 32);
     dh = sh;
     dst_pix_fmt = AV_PIX_FMT_YUV420P;
     std::string str = g_confile->GetValue("dst_pix_fmt", "video");


### PR DESCRIPTION
- Modified the calculation of `dw` to use `FFALIGN(sw, 32)` instead of `sw >> 2 << 2`.
- Ensured that the destination width is aligned to a multiple of 32, which improves compatibility with hardware decoders (e.g., h264_cuvid).
- This change resolves potential crashes caused by misaligned resolutions when using `sws_scale`.

Related logs:
- Original resolution (888x550) caused crashes due to unaligned width.
- After alignment, the issue was resolved and the program runs stably."